### PR TITLE
Fix DisappearingArtifacts test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master ]
   workflow_dispatch:
+    inputs:
+      gradleArgs:
+        description: 'Gradle args: use this to limit tests e.g. test --tests "..."'
+        required: true
+        default: 'check'
 
 jobs:
   build:
@@ -58,6 +63,14 @@ jobs:
           org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
           EOF
 
+      - id: getGradleArgs
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+              echo '::set-output name=args::${{ github.event.inputs.gradleArgs }}'
+          else
+              echo '::set-output name=args::check'
+          fi
+
       - name: Gradle
         env:
           JAVA_HOME: ${{ steps.setup-java-11.outputs.path }}
@@ -69,7 +82,7 @@ jobs:
           -PtestIgnoreFailures=true
           -PgithubRepo=$GITHUB_REPOSITORY
           -PgitDescribe=$GITHUB_SHA
-          check
+          ${{ steps.getGradleArgs.outputs.args }}
 
       - name: Archive JUnit XML Artifacts
         if: always()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "fallout-oss",
+    "name": "fallout",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/src/test/java/com/datastax/fallout/runner/ArtifactsTest.java
+++ b/src/test/java/com/datastax/fallout/runner/ArtifactsTest.java
@@ -112,12 +112,16 @@ class ArtifactsTest
         {
             assertThatCode(() -> {
                 int maxArtifacts = 0;
-                for (var i = 0; i != 100; ++i)
+
+                // Try to provoke an exception for at least 100 attempts, then
+                // continue for a maximum of 1000 attempts to get a non-zero result
+                for (var i = 0; i <= 100 || (i <= 1000 && maxArtifacts == 0); ++i)
                 {
                     final var testRunArtifacts = findTestRunArtifacts();
                     assertThat(testRunArtifacts).isSubsetOf(completeExpectedArtifacts);
                     maxArtifacts = Math.max(maxArtifacts, testRunArtifacts.size());
                 }
+
                 assertThat(maxArtifacts)
                     .withFailMessage("At least one call resulted in _some_ artifacts")
                     .isGreaterThan(0);


### PR DESCRIPTION
Tries harder to get a non-zero artifact listing in DisappearingArtifactsTest.

Also makes it possible to run the ci.yaml action manually with a gradle args parameter.