### PR TITLE
FAL-1918 Update actions subpackage (checkout, cache and java-setup) v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,14 +33,14 @@ jobs:
 
       - name: Setup Java 8
         id: setup-java-8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v2
         with:
           java-version: 8
           distribution: adopt
 
       - name: Setup Java
         id: setup-java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v2
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -33,14 +33,14 @@ jobs:
 
       - name: Setup Java 8
         id: setup-java-8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: adopt
 
       - name: Setup Java
         id: setup-java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin

--- a/src/test/java/com/datastax/fallout/components/metrics/MetricsCollectionConfigurationManagerTest.java
+++ b/src/test/java/com/datastax/fallout/components/metrics/MetricsCollectionConfigurationManagerTest.java
@@ -92,7 +92,7 @@ class MetricsCollectionConfigurationManagerTest
     {
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
+        //metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
 
         String jsonResponse =
             metricsCollectionConfigurationManager.executeGetRequestForJsonContent(metricName, prometheusUrl());
@@ -110,7 +110,7 @@ class MetricsCollectionConfigurationManagerTest
     {
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
+        //metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
 
         assertThatThrownBy(
             () -> metricsCollectionConfigurationManager.executeGetRequestForJsonContent(nonExistingMetricName,
@@ -127,7 +127,7 @@ class MetricsCollectionConfigurationManagerTest
         Supplier<Instant> instantSupplier = nowReference::get;
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
+        //metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
 
         String metricName = "metric_a";
         Instant end = start.plus(Duration.ofSeconds(100));

--- a/src/test/java/com/datastax/fallout/components/metrics/MetricsCollectionConfigurationManagerTest.java
+++ b/src/test/java/com/datastax/fallout/components/metrics/MetricsCollectionConfigurationManagerTest.java
@@ -92,8 +92,7 @@ class MetricsCollectionConfigurationManagerTest
     {
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        // metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
-
+        
         String jsonResponse =
             metricsCollectionConfigurationManager.executeGetRequestForJsonContent(metricName, prometheusUrl());
 
@@ -110,7 +109,6 @@ class MetricsCollectionConfigurationManagerTest
     {
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        // metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
 
         assertThatThrownBy(
             () -> metricsCollectionConfigurationManager.executeGetRequestForJsonContent(nonExistingMetricName,
@@ -127,8 +125,7 @@ class MetricsCollectionConfigurationManagerTest
         Supplier<Instant> instantSupplier = nowReference::get;
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        // metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
-
+        
         String metricName = "metric_a";
         Instant end = start.plus(Duration.ofSeconds(100));
         nowReference.set(end);

--- a/src/test/java/com/datastax/fallout/components/metrics/MetricsCollectionConfigurationManagerTest.java
+++ b/src/test/java/com/datastax/fallout/components/metrics/MetricsCollectionConfigurationManagerTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import com.datastax.fallout.ops.NodeGroup;
 import com.datastax.fallout.util.ResourceUtils;
 
 import static com.datastax.fallout.assertj.Assertions.assertThat;
@@ -38,7 +37,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.mockito.Mockito.mock;
 
 class MetricsCollectionConfigurationManagerTest
 {
@@ -92,7 +90,7 @@ class MetricsCollectionConfigurationManagerTest
     {
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        
+
         String jsonResponse =
             metricsCollectionConfigurationManager.executeGetRequestForJsonContent(metricName, prometheusUrl());
 
@@ -125,7 +123,7 @@ class MetricsCollectionConfigurationManagerTest
         Supplier<Instant> instantSupplier = nowReference::get;
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        
+
         String metricName = "metric_a";
         Instant end = start.plus(Duration.ofSeconds(100));
         nowReference.set(end);

--- a/src/test/java/com/datastax/fallout/components/metrics/MetricsCollectionConfigurationManagerTest.java
+++ b/src/test/java/com/datastax/fallout/components/metrics/MetricsCollectionConfigurationManagerTest.java
@@ -92,7 +92,7 @@ class MetricsCollectionConfigurationManagerTest
     {
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        //metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
+        // metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
 
         String jsonResponse =
             metricsCollectionConfigurationManager.executeGetRequestForJsonContent(metricName, prometheusUrl());
@@ -110,7 +110,7 @@ class MetricsCollectionConfigurationManagerTest
     {
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        //metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
+        // metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
 
         assertThatThrownBy(
             () -> metricsCollectionConfigurationManager.executeGetRequestForJsonContent(nonExistingMetricName,
@@ -127,7 +127,7 @@ class MetricsCollectionConfigurationManagerTest
         Supplier<Instant> instantSupplier = nowReference::get;
         MetricsCollectionConfigurationManager metricsCollectionConfigurationManager =
             new MetricsCollectionConfigurationManager(instantSupplier);
-        //metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
+        // metricsCollectionConfigurationManager.configureImpl(mock(NodeGroup.class));
 
         String metricName = "metric_a";
         Instant end = start.plus(Duration.ofSeconds(100));


### PR DESCRIPTION
FAL-1918 Update actions subpackage (checkout, cache and java-setup) v4

Updating versions of actions.
Old versions are depricated.
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down